### PR TITLE
deleting my rental option as it is not needed anymore

### DIFF
--- a/mini-cap/src/components/Navbar.js
+++ b/mini-cap/src/components/Navbar.js
@@ -135,14 +135,6 @@ const Navbar = () => {
                     />
                 )}
 
-                {store("role") === "renter/owner" && (
-                    <DropdownItem
-                        address={"/myproperty"}
-                        icon={<AiOutlineHome />}
-                        text={"My rental"}
-                    />
-                )}
-
                 {store("role") !== "renter/owner" && (
                     <DropdownItem
                         address={"/propertyprofile"}


### PR DESCRIPTION
here is the updated look of the navbar 
![image](https://github.com/leobrod44/Mini-Capstone/assets/93160873/5e994ff9-7f99-42db-9094-1095b0272616)


The myrental option was created in sprint 1 when we thought we would have 2 separate dashboards- one for renter and one for owner. This design has since been changed to a single dashboard, including all condos (which are distinguished between rented and owned using a blue and green tag). So, to keep our website consistent with our design, i have deleted this option.