### PR TITLE
Fixing css bug for sendkeypopup

### DIFF
--- a/mini-cap/src/styling/Popup.css
+++ b/mini-cap/src/styling/Popup.css
@@ -8,6 +8,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 9999; /* Ensure the popup appears above other elements */
+
   }
   
   .popup_content {


### PR DESCRIPTION
fixes #182


Fixed the bug where the unit number was appearing above the popup


unable to fix the css toast validation bug.
despite using e.preventdefault(), and even inserting novalidation to the component, the browser still seems to be taking the default browser validation and im unable to remove it or fix it.


![image](https://github.com/leobrod44/Mini-Capstone/assets/93160873/3a4f52ff-94ef-4e9b-a646-4ede2624c259)
